### PR TITLE
Update centralize_test_failures.sql to utilize adapter dispatch and m…

### DIFF
--- a/dbt/macros/test_analytics/centralize_test_failures.sql
+++ b/dbt/macros/test_analytics/centralize_test_failures.sql
@@ -1,4 +1,66 @@
-{% macro centralize_test_failures(results) %}
+{% macro centralize_test_failures(results) -%}
+    {{ return(adapter.dispatch('centralize_test_failures')(results)) }}
+{%- endmacro %}
+
+{% macro bigquery__centralize_test_failures(results) %}
+  {# --add "{{ centralize_test_failures(results) }}" to an on-run-end: block in dbt_project.yml #}
+  {# --run with dbt build --store-failures. The next v.1.0.X release of dbt will include post run hooks for dbt test! #}
+  {%- set test_results = [] -%}
+  {%- for result in results -%}
+    {%- if result.node.resource_type == 'test' and result.status != 'skipped' and (
+          result.node.config.get('store_failures') or flags.STORE_FAILURES
+      )
+    -%}
+      {%- do test_results.append(result) -%}
+    {%- endif -%}
+  {%- endfor -%}
+  
+  {%- set central_tbl -%} {{ target.schema }}.test_failure_central {%- endset -%}
+  {%- set history_tbl -%} {{ target.schema }}.test_failure_history {%- endset -%}
+  
+  {{ log("Centralizing test failures in " + central_tbl, info = true) if execute }}
+
+  create or replace table {{ central_tbl }} as (
+  
+  {% for result in test_results %}
+    
+    select
+      '{{ result.node.name }}' as test_name,
+      '{{ result.node.unique_id }}' as model_name,
+      to_json_string((select as struct * from unnest([relation]))) as test_failures_json,
+      current_timestamp as _timestamp
+      
+    from {{ result.node.relation_name }} as relation
+    
+    {{ "union all" if not loop.last }}
+  
+  {% endfor %}
+  
+  );
+  
+  -- only run centralization in higher environments
+  {% if target.name != 'default' %}
+      create table if not exists {{ history_tbl }} as (
+        select 
+          {{ dbt_utils.surrogate_key(["test_name", "test_failures_json", "_timestamp"]) }} as sk_id, 
+          * 
+        from {{ central_tbl }}
+        where false
+      );
+
+    insert into {{ history_tbl }} 
+      select 
+       {{ dbt_utils.surrogate_key(["test_name", "test_failures_json", "_timestamp"]) }} as sk_id, 
+       * 
+      from {{ central_tbl }}
+    ;
+  {% endif %}
+
+{% endmacro %}
+
+
+
+{% macro snowflake__centralize_test_failures(results) %}
   {# --add "{{ centralize_test_failures(results) }}" to an on-run-end: block in dbt_project.yml #}
   {# --run with dbt build --store-failures. The next v.1.0.X release of dbt will include post run hooks for dbt test! #}
   {%- set test_results = [] -%}


### PR DESCRIPTION
…ake available for bigquery users

added a bigquery equivalent of <object_construct> by replacing the function with a to_json_string((select * from struct)) etc. added adapter dispatch for ease of use and distribution.

### This PR includes:
- bigquery equivalent of centralize_test_failures macro
- adapter dispatch for ease of use across snowflake and bigquery

